### PR TITLE
Use WebID Profile Document consistently

### DIFF
--- a/spec/identity/index.html
+++ b/spec/identity/index.html
@@ -435,7 +435,7 @@ URI: <a href="https://dvcs.w3.org/hg/WebID">https://dvcs.w3.org/hg/WebID</a>
 
 
 
-</div><div id="toc" class="section"><h2 class="introductory" id="h2_toc">Table of Contents</h2><ul class="toc" id="respecContents"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a><ul class="toc"><li class="tocline"><a href="#outline" class="tocxref"><span class="secno">1.1 </span>Outline</a></li></ul></li><li class="tocline"><a href="#terminology" class="tocxref"><span class="secno">2. </span>Terminology</a><ul class="toc"><li class="tocline"><a href="#namespaces" class="tocxref"><span class="secno">2.1 </span>Namespaces</a></li></ul></li><li class="tocline"><a href="#the-webid-http-uri" class="tocxref"><span class="secno">3. </span>The WebID HTTP URI</a></li><li class="tocline"><a href="#overview" class="tocxref"><span class="secno">4. </span>Overview</a></li><li class="tocline"><a href="#publishing-the-webid-profile-document" class="tocxref"><span class="secno">5. </span>Publishing the WebID Profile Document</a><ul class="toc"><li class="tocline"><a href="#webid-profile-vocabulary" class="tocxref"><span class="secno">5.1 </span>WebID Profile Vocabulary</a><ul class="toc"><li class="tocline"><a href="#personal-information" class="tocxref"><span class="secno">5.1.1 </span>Personal Information</a></li></ul></li><li class="tocline"><a href="#publishing-a-webid-profile-using-turtle" class="tocxref"><span class="secno">5.2 </span>Publishing a WebID Profile using Turtle</a></li><li class="tocline"><a href="#publishing-a-webid-profile-using-the-rdfa-html-notation" class="tocxref"><span class="secno">5.3 </span>Publishing a WebID Profile using the RDFa HTML notation</a></li><li class="tocline"><a href="#privacy" class="tocxref"><span class="secno">5.4 </span>Privacy</a></li><li class="tocline"><a href="#security-considerations" class="tocxref"><span class="secno">5.5 </span>Security Considerations</a></li></ul></li><li class="tocline"><a href="#processing-the-webid-profile" class="tocxref"><span class="secno">6. </span>Processing the WebID Profile</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">7. </span>Acknowledgments</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ul></li></ul></div>
+</div><div id="toc" class="section"><h2 class="introductory" id="h2_toc">Table of Contents</h2><ul class="toc" id="respecContents"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a><ul class="toc"><li class="tocline"><a href="#outline" class="tocxref"><span class="secno">1.1 </span>Outline</a></li></ul></li><li class="tocline"><a href="#terminology" class="tocxref"><span class="secno">2. </span>Terminology</a><ul class="toc"><li class="tocline"><a href="#namespaces" class="tocxref"><span class="secno">2.1 </span>Namespaces</a></li></ul></li><li class="tocline"><a href="#the-webid-http-uri" class="tocxref"><span class="secno">3. </span>The WebID HTTP URI</a></li><li class="tocline"><a href="#overview" class="tocxref"><span class="secno">4. </span>Overview</a></li><li class="tocline"><a href="#publishing-the-webid-profile-document" class="tocxref"><span class="secno">5. </span>Publishing the WebID Profile Document</a><ul class="toc"><li class="tocline"><a href="#webid-profile-vocabulary" class="tocxref"><span class="secno">5.1 </span>WebID Profile Document Vocabulary</a><ul class="toc"><li class="tocline"><a href="#personal-information" class="tocxref"><span class="secno">5.1.1 </span>Personal Information</a></li></ul></li><li class="tocline"><a href="#publishing-a-webid-profile-using-turtle" class="tocxref"><span class="secno">5.2 </span>Publishing a WebID Profile Document using Turtle</a></li><li class="tocline"><a href="#publishing-a-webid-profile-using-the-rdfa-html-notation" class="tocxref"><span class="secno">5.3 </span>Publishing a WebID Profile Document using the RDFa HTML notation</a></li><li class="tocline"><a href="#privacy" class="tocxref"><span class="secno">5.4 </span>Privacy</a></li><li class="tocline"><a href="#security-considerations" class="tocxref"><span class="secno">5.5 </span>Security Considerations</a></li></ul></li><li class="tocline"><a href="#processing-the-webid-profile" class="tocxref"><span class="secno">6. </span>Processing the WebID Profile Document</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">7. </span>Acknowledgments</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ul></li></ul></div>
 
 
 
@@ -445,9 +445,9 @@ URI: <a href="https://dvcs.w3.org/hg/WebID">https://dvcs.w3.org/hg/WebID</a>
 <h2 id="h2_introduction"><span class="secno">1. </span>Introduction</h2><p><em>This section is non-normative.</em></p>
 
 <p>
-A WebID is an HTTP URI that refers to an Agent (Person, Organization, Group, Device, etc.). A description of the WebID can be found in the <a class="tref internalDFN" title="Profile_Document" href="#dfn-profile_document">Profile Document</a>, a type of web page that would be familiar to any Social Network user.</p>
+A WebID is an HTTP URI that refers to an Agent (Person, Organization, Group, Device, etc.). A description of the WebID can be found in the <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile Document</a>, a type of web page that would be familiar to any Social Network user.</p>
 <p>
-A WebID <a class="tref internalDFN" title="Profile_Document" href="#dfn-profile_document">Profile Document</a> is a Web resource that <em class="rfc2119" title="MUST">MUST</em> be available as <code>text/turtle</code> [<cite><a class="bibref" href="#bib-turtle">turtle</a></cite>], but <em class="rfc2119" title="MAY">MAY</em> be available in other RDF serialization formats (e.g. [<cite><a class="bibref" href="#bib-RDFA-CORE">RDFA-CORE</a></cite>]) if requested through content negotiation.
+A <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile Document</a> is a Web resource that <em class="rfc2119" title="MUST">MUST</em> be available as <code>text/turtle</code> [<cite><a class="bibref" href="#bib-turtle">turtle</a></cite>], but <em class="rfc2119" title="MAY">MAY</em> be available in other RDF serialization formats (e.g. [<cite><a class="bibref" href="#bib-RDFA-CORE">RDFA-CORE</a></cite>]) if requested through content negotiation.
 </p>
 <p>
 WebIDs can be used to build a Web of trust using vocabularies such as FOAF [<cite><a class="bibref" href="#bib-FOAF">FOAF</a></cite>] by allowing people to link their profiles in a public or protected manner.
@@ -461,8 +461,8 @@ Such a web of trust can then be used by a <a class="tref internalDFN" title="Ser
 <p><a href="#terminology">Section 2</a> provides a short description for the most commonly used terms in this document.</p>
 <p><a href="#the-webid-http-uri">Section 3</a> describes what a WebID URI is.</p>
 <p><a href="#overview">Section 4</a> presents an overview of WebID.</p>
-<p><a href="#publishing-the-webid-profile-document">Section 5</a> deals with the publishing of a <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile</a>.</p>
-<p><a href="#processing-the-webid-profile">Section 6</a> describes how a request for a <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile</a> should be handled.</p>
+<p><a href="#publishing-the-webid-profile-document">Section 5</a> deals with the publishing of a <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile Document</a>.</p>
+<p><a href="#processing-the-webid-profile">Section 6</a> describes how a request for a <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile Document</a> should be handled.</p>
 </div>
 </div>
 
@@ -482,12 +482,12 @@ Such a web of trust can then be used by a <a class="tref internalDFN" title="Ser
 <dd>A Service is an agent listening for requests at a particular domain name or IP address on a given Server.</dd>
 
 <dt><dfn title="WebID" id="dfn-webid">WebID</dfn></dt>
-<dd>A WebID is a URI with an HTTP or HTTPS scheme that denotes an Agent (Person, Organization, Group, Device, etc.). For WebIDs with fragment identifiers (e.g. #me), the URI without the fragment denotes the Profile Document. For WebIDs without fragment identifiers an HTTP request on the WebID <em class="rfc2119" title="MUST">MUST</em> return a 303 with a Location header URI referring to the Profile Document.
+<dd>A WebID is a URI with an HTTP or HTTPS scheme that denotes an Agent (Person, Organization, Group, Device, etc.). For WebIDs with fragment identifiers (e.g. #me), the URI without the fragment denotes the WebID Profile Document. For WebIDs without fragment identifiers an HTTP request on the WebID <em class="rfc2119" title="MUST">MUST</em> return a 303 with a Location header URI referring to the WebID Profile Document.
 </dd>
 
-<dt><dfn title="WebID_Profile" id="dfn-webid_profile">WebID Profile</dfn> or <dfn title="Profile_Document" id="dfn-profile_document">Profile Document</dfn></dt>
+<dt><dfn title="WebID_Profile" id="dfn-webid_profile">WebID Profile Document</dfn></dt>
 <dd>
-A WebID Profile is an RDF document that uniquely describes the Agent denoted by the WebID in relation to that WebID. The server <em class="rfc2119" title="MUST">MUST</em> provide a <code>text/turtle</code> [<cite><a class="bibref" href="#bib-turtle">turtle</a></cite>] representation of the requested profile. This document <em class="rfc2119" title="MAY">MAY</em> be available in other RDF serialization formats, such as RDFa [<cite><a class="bibref" href="#bib-RDFA-CORE">RDFA-CORE</a></cite>], or [<cite><a class="bibref" href="#bib-RDF-SYNTAX-GRAMMAR">RDF-SYNTAX-GRAMMAR</a></cite>] if so requested through content negotiation.
+A WebID Profile Document is an RDF document that uniquely describes the Agent denoted by the WebID in relation to that WebID. The server <em class="rfc2119" title="MUST">MUST</em> provide a <code>text/turtle</code> [<cite><a class="bibref" href="#bib-turtle">turtle</a></cite>] representation of the requested profile. This document <em class="rfc2119" title="MAY">MAY</em> be available in other RDF serialization formats, such as RDFa [<cite><a class="bibref" href="#bib-RDFA-CORE">RDFA-CORE</a></cite>], or [<cite><a class="bibref" href="#bib-RDF-SYNTAX-GRAMMAR">RDF-SYNTAX-GRAMMAR</a></cite>] if so requested through content negotiation.
 </dd>
 </dl>
 
@@ -530,12 +530,12 @@ then his WebID can be <code>https://bob.example.org/profile#me</code>.</p>
 <!--OddPage-->
 <h2 id="h2_overview"><span class="secno">4. </span>Overview</h2><p><em>This section is non-normative.</em></p>
 
-<p>The relation between the <a class="tref internalDFN" title="WebID" href="#dfn-webid">WebID</a> URI and the <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile</a> document is illustrated below.</p>
+<p>The relation between the <a class="tref internalDFN" title="WebID" href="#dfn-webid">WebID</a> URI and the <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile Document</a> is illustrated below.</p>
 <img src="img/WebID-overview.png" alt="WebID overview" id="webid-diagram" />
 
 <p>The WebID URI - <em><a href="http://www.w3.org/People/Berners-Lee/card#i">http://www.w3.org/People/Berners-Lee/card<strong>#i</strong></a>&quot;</em> (containing the <strong>#i</strong> hash tag) - is an identifier that denotes (refers to) a person or more generally an agent. In the above illustration, the referent is Tim Berners Lee, a real physical person who has a history, who invented the World Wide Web, and who directs the World Web Consortium.
-</p><p>The WebID Profile URI - <em>&quot;<a href="http://www.w3.org/People/Berners-Lee/card">http://www.w3.org/People/Berners-Lee/card</a>&quot;</em> (without the <strong>#i</strong> hash tag) - denotes the document describing the person (or more generally any agent) who is the referent of the WebID URI.</p>
-<p>The WebID Profile gives the meaning of the WebID: its RDF Graph contains a <a href="http://www.w3.org/Submission/CBD/">Concise Bounded Description</a> of the WebID such that this subgraph forms a definite description of the referent of the WebID, that is, a description that distinguishes the referent of that WebID from all other things in the world.<br />
+</p><p>The WebID Profile Document URI - <em>&quot;<a href="http://www.w3.org/People/Berners-Lee/card">http://www.w3.org/People/Berners-Lee/card</a>&quot;</em> (without the <strong>#i</strong> hash tag) - denotes the document describing the person (or more generally any agent) who is the referent of the WebID URI.</p>
+<p>The WebID Profile Document gives the meaning of the WebID: its RDF Graph contains a <a href="http://www.w3.org/Submission/CBD/">Concise Bounded Description</a> of the WebID such that this subgraph forms a definite description of the referent of the WebID, that is, a description that distinguishes the referent of that WebID from all other things in the world.<br />
 The document can, for example, contain relations to other documents depicting the WebID referent, or it can relate the WebID to principals used by different authentication protocols.
 (More information on WebID and other authentication protocols can be found on the <a href="http://www.w3.org/2005/Incubator/webid/wiki/Identity_Interoperability">WebID Identity Interoperability</a> page).
 </p>
@@ -547,7 +547,7 @@ The document can, for example, contain relations to other documents depicting th
 <h2 id="h2_publishing-the-webid-profile-document"><span class="secno">5. </span>Publishing the WebID Profile Document</h2>
 
 <p>
-WebID requires that servers <em class="rfc2119" title="MUST">MUST</em> at least be able to provide Turtle representation of profile documents, but other serialization formats of the graph are allowed, provided that agents are able to parse that serialization and obtain the graph automatically.
+WebID requires that servers <em class="rfc2119" title="MUST">MUST</em> at least be able to provide Turtle representation of WebID Profile Documents, but other serialization formats of the graph are allowed, provided that agents are able to parse that serialization and obtain the graph automatically.
 HTTP Content Negotiation can be employed to aid in publication and discovery of multiple distinct serializations of the same graph at the same URL, as explained in [<cite><a class="bibref" href="#bib-COOLURIS">COOLURIS</a></cite>]</p>
 
 <p>It is particularly useful to have one of the representations be in HTML
@@ -555,7 +555,7 @@ even if it is not marked up in RDFa, as this allows people using a
 web browser to understand what the information at that URI represents.</p>
 
 <div class="normative section" id="webid-profile-vocabulary">
-<h3 id="h3_webid-profile-vocabulary"><span class="secno">5.1 </span>WebID Profile Vocabulary</h3>
+<h3 id="h3_webid-profile-vocabulary"><span class="secno">5.1 </span>WebID Profile Document Vocabulary</h3>
 
 <p>WebID RDF graphs are built using vocabularies identified by URIs, that can be placed in subject, predicate or object position of the relations constituting the graph.
     The definition of each URI should be found at the namespace of the URI, by dereferencing it.
@@ -568,7 +568,7 @@ web browser to understand what the information at that URI represents.</p>
 account with a website. Some of these pieces of information include an e-mail
 address, a name and perhaps an avatar image, expressed using the FOAF [<cite><a class="bibref" href="#bib-FOAF">FOAF</a></cite>] vocabulary. This section includes
 properties that <em class="rfc2119" title="SHOULD">SHOULD</em> be used when conveying key pieces of personal information
-but are <em class="rfc2119" title="NOT REQUIRED">NOT REQUIRED</em> to be present in a <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile</a>:</p>
+but are <em class="rfc2119" title="NOT REQUIRED">NOT REQUIRED</em> to be present in a <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile Document</a>:</p>
 <dl>
   <dt>foaf:name</dt>
   <dd>The name of the individual or agent.</dd>
@@ -585,10 +585,10 @@ but are <em class="rfc2119" title="NOT REQUIRED">NOT REQUIRED</em> to be present
 <p>A widely used format for writing RDF graphs by hand is the <a href="http://www.w3.org/TR/turtle/">Turtle</a> [<cite><a class="bibref" href="#bib-turtle">turtle</a></cite>] notation.
     It is easy to learn, and very handy for communicating over e-mail and on mailing lists.
     The syntax is very similar to the <a href="http://www.w3.org/TR/rdf-sparql-query/">SPARQL</a> query language.
-    Turtle profile documents should be served with the <code>text/turtle</code> content type.
+    WebID Profile Documents in Turtle should be served with the <code>text/turtle</code> content type.
 </p>
 <p>
-Take for example the WebID <em>https://bob.example.org/profile#me</em>, for which the WebID Profile document contains the following Turtle representation:
+Take for example the WebID <em>https://bob.example.org/profile#me</em>, for which the WebID Profile Document contains the following Turtle representation:
 </p>
 <div class="example"><div class="example-title"><span>Example 1</span></div><pre style="word-wrap: break-word; white-space: pre-wrap;" class="example">@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .
 
@@ -602,10 +602,10 @@ Take for example the WebID <em>https://bob.example.org/profile#me</em>, for whic
    foaf:img &lt;https://bob.example.org/picture.jpg&gt; .</pre></div>
 </div>
 <div class="informative section" id="publishing-a-webid-profile-using-the-rdfa-html-notation">
-<h3 id="h3_publishing-a-webid-profile-using-the-rdfa-html-notation"><span class="secno">5.3 </span>Publishing a WebID Profile using the RDFa HTML notation</h3><p><em>This section is non-normative.</em></p>
+<h3 id="h3_publishing-a-webid-profile-using-the-rdfa-html-notation"><span class="secno">5.3 </span>Publishing a WebID Profile Document using the RDFa HTML notation</h3><p><em>This section is non-normative.</em></p>
 <p>RDFa in HTML [<cite><a class="bibref" href="#bib-RDFA-CORE">RDFA-CORE</a></cite>] is a way to markup HTML with relations that have a well defined semantics and
     mapping to an RDF graph.  There are many ways of writing out the above graph using RDFa in
-HTML. Here is just one example of what a WebID profile could look like.
+HTML. Here is just one example of what a WebID Profile Document could look like.
 </p>
 <div class="example"><div class="example-title"><span>Example 2</span></div><pre style="word-wrap: break-word; white-space: pre-wrap;" class="example">&lt;div vocab=&quot;http://xmlns.com/foaf/0.1/&quot; about=&quot;#me&quot; typeof=&quot;foaf:Person&quot;&gt;
   &lt;p&gt;My name is &lt;span property=&quot;name&quot;&gt;Bob&lt;/span&gt; and this is how I look like: &lt;img property=&quot;img&quot; src=&quot;https://bob.example.org/picture.jpg&quot; title=&quot;Bob&quot; alt=&quot;Bob&quot; /&gt;&lt;/p&gt;
@@ -614,7 +614,7 @@ HTML. Here is just one example of what a WebID profile could look like.
     &lt;li property=&quot;knows&quot; href=&quot;https://example.edu/p/Alice#MSc&quot;&gt;Alice&lt;/li&gt;
   &lt;/ul&gt;
 &lt;/div&gt;</pre></div>
-<p>If a WebID provider would prefer not to mark up his WebID profile in HTML+RDFa, but
+<p>If a WebID provider would prefer not to mark up his WebID Profile Document in HTML+RDFa, but
 just provide a human readable format for users in plain HTML and have the RDF graph appear
 in a machine readable format such as Turtle, then he <em class="rfc2119" title="SHOULD">SHOULD</em> provide a link of type <code>alternate</code>
 to a machine readable format [<cite><a class="bibref" href="#bib-RFC5988">RFC5988</a></cite>]. This can be placed in the HTTP header or in the
@@ -676,10 +676,10 @@ In the following example, Bob is limiting access to his list of friends, by plac
 
 <div class="informative section" id="security-considerations">
 <h3 id="h3_security-considerations"><span class="secno">5.5 </span>Security Considerations</h3><p><em>This section is non-normative.</em></p>
-<p>A <a class="tref internalDFN" title="WebID" href="#dfn-webid">WebID</a> identifies an agent via a description found in the associated <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile</a> document.
+<p>A <a class="tref internalDFN" title="WebID" href="#dfn-webid">WebID</a> identifies an agent via a description found in the associated <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile Document</a>.
 An agent that wishes to know what a WebID refers to, must rely on the description found in the WebID Profile.
-An attack on the relation between the <a class="tref internalDFN" title="WebID" href="#dfn-webid">WebID</a> and the <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile</a> can thus be used
-to subvert the meaning of the WebID, and to make agents following links within the <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile</a> come to different conclusions from those intended by profile owners.
+An attack on the relation between the <a class="tref internalDFN" title="WebID" href="#dfn-webid">WebID</a> and the <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile Document</a> can thus be used
+to subvert the meaning of the WebID, and to make agents following links within the <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">WebID Profile Document</a> come to different conclusions from those intended by profile owners.
 </p>
 <p>
 The standard way of overcoming such attacks is to rely on the cryptographic security protocols within the HTTPS [<cite><a class="bibref" href="#bib-HTTP-TLS">HTTP-TLS</a></cite>] stack.
@@ -700,7 +700,7 @@ As security is constantly being challenged by new attacks, to which new response
 <div class="normative section" id="processing-the-webid-profile">
 
 <!--OddPage-->
-<h2 id="h2_processing-the-webid-profile"><span class="secno">6. </span>Processing the WebID Profile</h2>
+<h2 id="h2_processing-the-webid-profile"><span class="secno">6. </span>Processing the WebID Profile Document</h2>
 
 <p>The <a class="tref internalDFN" title="Requesting_Agent" href="#dfn-requesting_agent">Requesting Agent</a> needs to fetch the document, if it does not have a valid one in cache.
 The Agent requesting the WebID document <em class="rfc2119" title="MUST">MUST</em> be able to parse documents in Turtle [<cite><a class="bibref" href="#bib-turtle">turtle</a></cite>], but <em class="rfc2119" title="MAY">MAY</em> also be able to parse documents in RDF/XML [<cite><a class="bibref" href="#bib-RDF-SYNTAX-GRAMMAR">RDF-SYNTAX-GRAMMAR</a></cite>] and RDFa [<cite><a class="bibref" href="#bib-RDFA-CORE">RDFA-CORE</a></cite>].
@@ -712,7 +712,7 @@ For an agent that can parse Turtle, rdf/xml and RDFa, the following would be a r
 <code>Accept: text/turtle,application/rdf+xml,application/xhtml+xml;q=0.8,text/html;q=0.7</code>
 </p></div>
 
-<p>If the <a class="tref internalDFN" title="Requesting_Agent" href="#dfn-requesting_agent">Requesting Agent</a> wishes to have the most up-to-date Profile document for an HTTP URL, it can use the HTTP cache control headers to get the latest versions.</p>
+<p>If the <a class="tref internalDFN" title="Requesting_Agent" href="#dfn-requesting_agent">Requesting Agent</a> wishes to have the most up-to-date WebID Profile Document for an HTTP URL, it can use the HTTP cache control headers to get the latest versions.</p>
 </div>
 
 <div id="acknowledgements" class="informative section" typeof="bibo:Chapter" resource="#ref" rel="bibo:Chapter">


### PR DESCRIPTION
Closes #4 .

Edit: Using "WebID Profile Document" consistently. Replaced all other similar occurrences with that term. Kept the existing local identifier `dfn-webid_profile` and dropped `dfn-profile_document`.