### PR TITLE
Add description for specification's intended audience

### DIFF
--- a/spec/identity/index.html
+++ b/spec/identity/index.html
@@ -453,6 +453,14 @@ A <a class="tref internalDFN" title="WebID_Profile" href="#dfn-webid_profile">We
 WebIDs can be used to build a Web of trust using vocabularies such as FOAF [<cite><a class="bibref" href="#bib-FOAF">FOAF</a></cite>] by allowing people to link their profiles in a public or protected manner.
 Such a web of trust can then be used by a <a class="tref internalDFN" title="Service" href="#dfn-service">Service</a> to make authorization decisions, by allowing access to resources depending on the properties of an agent, such as that they are known by some relevant people, employed at a given company, a member of a family or some other group, etc.
 </p>
+<p>This specification is for:</p>
+<ul>
+  <li>Anyone that wants to understand the architectural principles and notions underlying WebID.</li>
+  <li>URI owners who want to allocate identifiers to denote agents.</li>
+  <li>Resource server developers who want to enable clients to consume WebIDs and their associated descriptions.</li>
+  <li>Application developers who want to implement a client to consume WebIDs.</li>
+  <li>Specification authors who want to integrate or extend WebID.</li>
+</ul>
 
 <div id="outline" class="section">
 <h3 id="h3_outline"><span class="secno">1.1 </span>Outline</h3>


### PR DESCRIPTION
Clarifying who this specification is for signals to the reader whether and what they might be able to get out of this specification. This text - which could be adapted as the spec progresses - can also serve as an editorial guide on expressing certain notions and structuring.