### PR TITLE
Add Note for recognising properties equivalent to foaf:primaryTopic

### DIFF
--- a/spec/identity/index.html
+++ b/spec/identity/index.html
@@ -713,7 +713,7 @@ For an agent that can parse Turtle, rdf/xml and RDFa, the following would be a r
 </p></div>
 
 <div class="note"><div class="note-title" id="h_note_3"><span>Note</span></div><p>
-Implementations that can recognise properties from different vocabularies as being equivalent to <code>foaf:primaryTopic</code> are encouraged to use WebID Profile Documents in the same as described in this specification.</p>
+Implementations that recognise related properties from different vocabularies as being equivalent to <code>foaf:primaryTopic</code> are encouraged to do so in their respective WebID Profile Documents, along the same lines described in this document.
 </p></div>
 
 <p>If the <a class="tref internalDFN" title="Requesting_Agent" href="#dfn-requesting_agent">Requesting Agent</a> wishes to have the most up-to-date WebID Profile Document for an HTTP URL, it can use the HTTP cache control headers to get the latest versions.</p>

--- a/spec/identity/index.html
+++ b/spec/identity/index.html
@@ -712,6 +712,10 @@ For an agent that can parse Turtle, rdf/xml and RDFa, the following would be a r
 <code>Accept: text/turtle,application/rdf+xml,application/xhtml+xml;q=0.8,text/html;q=0.7</code>
 </p></div>
 
+<div class="note"><div class="note-title" id="h_note_3"><span>Note</span></div><p>
+Implementations that can recognise properties from different vocabularies as being equivalent to <code>foaf:primaryTopic</code> are encouraged to use WebID Profile Documents in the same as described in this specification.</p>
+</p></div>
+
 <p>If the <a class="tref internalDFN" title="Requesting_Agent" href="#dfn-requesting_agent">Requesting Agent</a> wishes to have the most up-to-date WebID Profile Document for an HTTP URL, it can use the HTTP cache control headers to get the latest versions.</p>
 </div>
 


### PR DESCRIPTION
This PR is a https://www.w3.org/2023/Process-20230612/#class-2 change towards addressing https://github.com/w3c/WebID/issues/24