### PR TITLE
chore: adds the chair's working draft

### DIFF
--- a/working_documents/webid-core-jacopo.html
+++ b/working_documents/webid-core-jacopo.html
@@ -20,7 +20,7 @@
         shortName: "webid",
         xref: ["web-platform", "cooluris"],
         group: "webid",
-        edDraftURI: "https://jacoscaz.com/WebID/primary-spec/webid.html",
+        edDraftURI: "https://github.com/w3c/WebID/tree/main/working_documents/webid-core-jacopo.html",
       };
     </script>
     <style>

--- a/working_documents/webid-core-jacopo.html
+++ b/working_documents/webid-core-jacopo.html
@@ -1,0 +1,453 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Web Identity and Discovery [WebID]</title>
+    <script
+      src="https://www.w3.org/Tools/respec/respec-w3c"
+      class="remove"
+      defer
+    ></script>
+    <script class="remove">
+      // All config options at https://respec.org/docs/
+      var respecConfig = {
+        specStatus: "ED",
+        editors: [{ 
+          name: "Jacopo Scazzosi",
+          // url: "https://your-site.com",
+        }],
+        github: "w3c/WebID",
+        shortName: "webid",
+        xref: ["web-platform", "cooluris"],
+        group: "webid",
+        edDraftURI: "https://jacoscaz.com/WebID/primary-spec/webid.html",
+      };
+    </script>
+    <style>
+      /* 
+       * This is a slightly modified version of the .sidenote class from
+       * Tufte's CSS - https://edwardtufte.github.io/tufte-css/ .
+       * Remove before submitting this document.
+       */
+      .sidenote {
+        float: right;
+        clear: right;
+        margin-right: -70%;
+        width: 60%;
+        margin-bottom: 0;
+        line-height: 1.3;
+        vertical-align: baseline;
+        position: relative;
+        font-size: 0.9rem;
+        font-style: italic;
+        font-family: Georgia, 'Times New Roman', Times, serif;
+      }
+      /* 
+       * Small tweaks to ReSpec's default layout to accomodate for sidenotes.
+       * Remove before submitting this document.
+       */
+       body {
+        margin: 0 !important;
+       }
+       section {
+        clear: both;
+       }
+    </style>
+  </head>
+  <body>
+    <section id="abstract">
+      <span class="sidenote">
+        <ul>
+          <li>Bootstrapped from [= Melvin's draft =]</li>
+          <li>Tracking conversation in [= Meaning of the term WebID =]</li>
+        </ul>
+      </span>
+      <p>
+        This specification defines a standard means by which user agents and
+        servers interact to establish a user's identity, ensuring a structured,
+        decentralized approach for identity discovery on the web.
+      </p>
+    </section>
+    <section id="sotd">
+      <!-- <p>This is required.</p> -->
+    </section>
+    <section class="informative">
+      <span class="sidenote">
+        <ul>
+          <li>Bootstrapped from [= Melvin's draft =]</li>
+          <li>
+            relationship between format and feature subspecs is being discussed
+            in [= Orthogonality of format subspecs vs. feature subspecs =] and
+            [= Relationship between superspec and subspecs =]
+          </li>
+          <li>
+            Use of IRI as per [= URL vs. URI vs. IRI =]
+          </li>
+        </ul>
+      </span>
+      <h2>Introduction</h2>
+      <p>
+        This specification delineates an HTTP IRI denoting an Agent that, when
+        dereferenced, leads to an RDF document describing such Agent.
+      </p>
+      <p>
+        This specification aims to act as a succinct, adaptable framework,
+        achieving universality and broad applicability without necessitating
+        further modifications to the primary specification. To this end, it
+        encompasses an open-ended list of [= Extension Profiles =].
+      </p>
+    </section>
+    <section>
+      <span class="sidenote">
+        <ul>
+          <li>Bootstrapped from [= Basic definitions =]</li>
+          <li>Changed to address [= Circularity concerns =]</li>
+          <li>
+            Usage of <em>unambiguously</em> is being discussed in 
+            [= Use of the term unambiguously =]
+          </li>
+          <li>
+            Use of IRI as per [= URL vs. URI vs. IRI =]
+          </li>
+          <li>
+            Moved further description of what Profile Documents should
+            consist of to dedicated section as it was getting to complex
+            to fit here
+          </li>
+          <li>
+            Todo: definition of Agent, currently taken from
+            <a href="http://xmlns.com/foaf/0.1/#term_Agent">foaf:Agent</a>
+          </li>
+        </ul>
+      </span>
+      <h2>Definitions</h2>
+      <dl>
+        <dt><dfn>WebID</dfn></dt>
+        <dd>
+          An identifier in the form of an HTTP IRI for naming an [= Agent =]
+          which, when dereferenced, must always lead to a [= Profile Document =]
+          describing the [= Agent =] named by the WebID itself.
+        </dd>
+        <dt><dfn>Profile Document</dfn></dt>
+        <dd>
+          An RDF document that describes an [= Agent =].
+        </dd>
+        <dt><dfn>Agent</dfn></dt>
+        <dd>
+          A thing that does stuff.
+        </dd>
+      </dl>
+    </section>
+    <section class="conformance">
+      <span class="sidenote">
+        <ul>
+        </ul>
+      </span>
+      <h2>WebIDs and Profile Documents</h2>
+      <p>
+        A WebID denotes an [= Agent =], an entity whose nature is different
+        from that of a document, while ultimately dereferencing to an actual
+        document - an [= Profile Document =] - that describes such [= Agent =].
+        This specification models this relationship according to the guidelines
+        on IRIs for documents and real-world objects defined in [[cooluris]].
+      </p>
+      <p>
+        For WebIDs with fragment identifiers, requests made against each WebID
+        stripped of its fragment identifier MUST dereference to the respective
+        [= Profile Document =]. Client HTTP libraries conforming to the HTTP
+        standard will automatically strip the fragment before sending requests
+        to the server.
+      </p> 
+      <p>
+        For WebIDs without fragment identifiers, requests made against each
+        WebID MUST dereference to the respective [= Profile Document =] by
+        means of redirection. Each request MUST be answered with the 
+        `303 See Other` status code and the `Location` header set to an IRI
+        that MUST dereference to the respective [= Profile Document =].
+    </section>
+    <section class="conformance">
+      <span class="sidenote">
+        <ul>
+          <li>
+            Contents of Profile Documents discussed in
+            [= Ontologies and statements RFC =] and 
+            [= primaryTopic vs isPrimaryTopicOf =]
+          </li>
+          <li>
+            Relationship between the spec, serialization formats and extension
+            profiles touched upon in [= Subsets of the superset =] and 
+            [= Relationship between primary spec and Extension Profiles =]
+          </li>
+          <li>
+            Serialization formats were the primary topic that started the long
+            discussion thread [= Required RDF serialization of WebID resource =],
+            which indicates convergence towards a MUST on Turtle and JSON-LD for
+            publishers.
+          </li>
+          <li>
+            `foaf:Agent` introduced in support of the possibility of
+            implementing the primary spec without necessariy also implementing
+            one of the authentication-related Extension Profiles
+            (see Nathan's view in [= Implementability concerns =] and
+            [= Relationship between primary spec and Extension Profiles =])
+            while limited to a SHOULD to preserve backward compatibility
+          </li>
+          <li>
+            Choice of `foaf` mainly driven by backward compatibility with
+            existing implementations and the fact that it is still under
+            active maintenance (see [= State of FOAF =]).
+          </li>
+        </ul>
+      </span>
+      <h2>Content and format of Profile Documents</h2>
+      <p>
+        A Profile Document MUST qualify the described [= Agent =] as the
+        document's `foaf:primaryTopic`.
+      </p>
+      <p>
+        Furthermore, a Profile Document SHOULD also qualify the described
+        [= Agent =] as having type `foaf:Agent`.
+      </p>
+      <p>
+        Publishers of Profile Documents MUST use Turtle or JSON-LD when
+        explicitly requested by consumers.
+      </p>
+      <aside class="example" title="Profile document in a JSON-LD data island">
+        <p>
+          The following snippet of code exemplifies a minimal Profile Document
+          using JSON-LD.
+        </p>
+        <pre class="json-ld">
+            {
+              "@context": {
+                "foaf": "http://xmlns.com/foaf/0.1/"
+              },
+              "@id": "https://example.com/rose",
+              "foaf:primaryTopic": {
+                "@id": "https://example.com/rose#me",
+                "@type": "Agent",
+                "foaf:name": "Rose Anderson"
+              }
+            }
+        </pre>
+        <p>
+          Interested readers may play around with this example at the 
+          <a href="https://json-ld.org/playground/#startTab=tab-nquads&json-ld=%7B%22%40context%22%3A%7B%22foaf%22%3A%22http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%22%7D%2C%22%40id%22%3A%22https%3A%2F%2Fexample.com%2Frose%22%2C%22foaf%3AprimaryTopic%22%3A%7B%22%40id%22%3A%22https%3A%2F%2Fexample.com%2Frose%23me%22%2C%22%40type%22%3A%22Agent%22%2C%22foaf%3Aname%22%3A%22Rose%20Anderson%22%7D%7D">
+            JSON-LD playground
+          </a>.
+        </p>
+      </aside>
+    </section>
+    <section class="conformance">
+      <span class="sidenote">
+        <ul>
+          <li>
+            relationship between format and feature subspecs is being discussed
+            in [= Orthogonality of format subspecs vs. feature subspecs =] and
+            [= Relationship between superspec and subspecs =]
+          </li>
+          <li>
+            format subspecs to be specified by the WebID CG are being discussed
+            in  [= Subsets of the Superset =]
+          </li>
+          <li>todo: link to WebID-TLS</li>
+        </ul>
+      </span>
+      <h2><dfn>Extension Profiles</dfn></h2>
+      <p>Following the <a href="https://www.w3.org/TR/spec-variability/"> note
+        on Spec Variability</a> by the W3C Working Group, sub-specifications
+        may build on top of the WebID specification by defining
+        <em>Extension Profiles</em> in support of specific features, such
+        as in the case of user authentication via WebID-TLS.
+      </p>
+    </section>
+    <section class="informative">
+      <span class="sidenote">
+        <ul>
+        </ul>
+      </span>
+      <h2>Acknowledgments</h2>
+      <p>
+        The authors acknowledge the contributions and discussions from the
+        WebID community and related working groups.
+      </p>
+    </section>
+    <section class="informative">
+      <h2>Sources</h2>
+      <p>
+        This section centralizes links to sources, proposals, suggestions and
+        feedbacks mentioned in sidenotes and is not meant to be included in the
+        final document but merely as a support for editing.
+      </p>
+      <ul>
+        <li>
+          <dfn>Melvin's draft</dfn>:
+          <a href="https://lists.w3.org/Archives/Public/public-webid/2023Nov/0052.html">
+            https://lists.w3.org/Archives/Public/public-webid/2023Nov/0052.html
+          </a>
+        </li>
+        <li>
+          <dfn>Basic definitions</dfn>:
+          <a href="https://github.com/w3c/WebID/issues/22#issue-1992942756">
+            https://github.com/w3c/WebID/issues/22#issue-1992942756
+          </a>
+        </li>
+        <li>
+          <dfn>Circularity concerns</dfn>:
+          <ul>
+            <li>
+              Jonas's:
+              <a href="https://github.com/w3c/WebID/issues/22#issuecomment-1810572993">
+                https://github.com/w3c/WebID/issues/22#issuecomment-1810572993
+              </a>
+            </li>
+            <li>
+              Aaron's: 
+              <a href="https://github.com/w3c/WebID/issues/22#issuecomment-1819619179">
+                https://github.com/w3c/WebID/issues/22#issuecomment-1819619179
+              </a>
+            </li>
+            <li>
+              Wouter's:
+              <a href="https://github.com/w3c/WebID/issues/22#issuecomment-1826231760">
+                https://github.com/w3c/WebID/issues/22#issuecomment-1826231760
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <dfn>Ontologies and statements RFC</dfn>
+          <a href="https://github.com/w3c/WebID/issues/23">
+            https://github.com/w3c/WebID/issues/23
+          </a>
+        </li>
+        <li>
+          <dfn>Implementability concerns</dfn>:
+          <ul>
+            <li>
+              Nathan's (echoed by Martynas):
+              <a href="https://github.com/w3c/WebID/issues/17#issuecomment-1806708994">
+                https://github.com/w3c/WebID/issues/17#issuecomment-1806708994
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <dfn>Orthogonality of format subspecs vs. feature subspecs</dfn>:
+          <a href="https://lists.w3.org/Archives/Public/public-webid/2023Nov/0144.html">
+            https://lists.w3.org/Archives/Public/public-webid/2023Nov/0144.html
+          </a>
+        </li>
+        <li>
+          <dfn>Relationship between superspec and subspecs</dfn>
+          <ul>
+            <li>
+              <dfn>Subsets of the Superset</dfn>:
+              <a href="https://github.com/w3c/WebID/issues/21">
+                https://github.com/w3c/WebID/issues/21
+              </a>
+            </li>
+            <li>Wouter's comment on [= Basic definitions =]
+              <a href="https://github.com/w3c/WebID/issues/22#issuecomment-1826231760">
+                https://github.com/w3c/WebID/issues/22#issuecomment-1826231760
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <dfn>primaryTopic vs isPrimaryTopicOf</dfn>
+          <a href="https://github.com/w3c/WebID/issues/24">
+            https://github.com/w3c/WebID/issues/24
+          </a>
+        </li>
+        <li>
+          <dfn>Use of the term unambiguously</dfn>
+          <a href="https://github.com/w3c/WebID/issues/25">
+            https://github.com/w3c/WebID/issues/25
+          </a>
+        </li>
+        <li>
+          <dfn>URL vs. URI vs. IRI</dfn>
+          <ul>
+            <li>
+              Switch from URI to IRI terminology in WebID spec
+              <a href="https://github.com/w3c/WebID/issues/10">
+                https://github.com/w3c/WebID/issues/10
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <dfn>Required RDF serialization of WebID resource</dfn>
+          <a href="https://github.com/w3c/WebID/issues/3">
+            https://github.com/w3c/WebID/issues/3
+          </a>
+        </li>
+        <li>
+          <dfn>Relationship between primary spec and Extension Profiles</dfn>
+          <ul>
+            <li>
+              Wouter's question
+              <a href="https://github.com/w3c/WebID/issues/22#issuecomment-1879125805">
+                https://github.com/w3c/WebID/issues/22#issuecomment-1879125805
+              </a>
+            </li>
+            <li>
+              Wouter's view, share by Jacopo
+              <a href="https://github.com/w3c/WebID/issues/22#issuecomment-1879289294">
+                https://github.com/w3c/WebID/issues/22#issuecomment-1879289294
+              </a>
+            </li>
+            <li>
+              Nathan's view, likely shared by Kingsley
+              <a href="https://github.com/w3c/WebID/issues/33#issue-2063107798">
+                https://github.com/w3c/WebID/issues/33#issue-2063107798
+              </a>
+            </li>
+            <li>
+              Nathan's view, reiterated
+              <a href="https://github.com/w3c/WebID/issues/17#issuecomment-1879530322">
+                https://github.com/w3c/WebID/issues/17#issuecomment-1879530322
+              </a>
+            </li>
+            <li>
+              Jacopo's attempt at working out the main differences between Wouter's and Nathan's views
+              <a href="https://github.com/w3c/WebID/issues/33#issuecomment-1878882129">
+                https://github.com/w3c/WebID/issues/33#issuecomment-1878882129
+              </a>
+            </li>
+            <li>
+              Jacopo's elaboration on the merits of Nathan's view
+              <a href="https://github.com/w3c/WebID/issues/22#issuecomment-1879273069">
+                https://github.com/w3c/WebID/issues/22#issuecomment-1879273069
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <dfn>State of FOAF</dfn>
+          <ul>
+            <li>
+              Dan's statement
+              <a href="https://github.com/w3c/WebID/issues/22#issuecomment-1868114977">
+                https://github.com/w3c/WebID/issues/22#issuecomment-1868114977
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <dfn>Meaning of the term WebID</dfn>
+          <p>Does it refer to a spec, a set of specs, a URL that denotes an Agent, ... ?</p>
+          <ul>
+            <li>
+              WebID a system, vs WebID an HTTP URI that
+              <a href="https://github.com/w3c/WebID/issues/40">
+                https://github.com/w3c/WebID/issues/40
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/working_documents/webid-core-jacopo.html
+++ b/working_documents/webid-core-jacopo.html
@@ -54,7 +54,7 @@
        }
     </style>
   </head>
-  <body>
+  <body>    
     <section id="abstract">
       <span class="sidenote">
         <ul>
@@ -68,8 +68,13 @@
         decentralized approach for identity discovery on the web.
       </p>
     </section>
-    <section id="sotd">
-      <!-- <p>This is required.</p> -->
+    <section id="sotd" class="override">
+      <h2>Status of this document</h2>
+      <p>
+        This is a personal working document that the chair of the WebID CG uses
+        to track and represent consensus.
+      </p>
+      <p><strong>This document is not a work item of the WebID CG.</strong></p>
     </section>
     <section class="informative">
       <span class="sidenote">
@@ -276,8 +281,7 @@
       <h2>Sources</h2>
       <p>
         This section centralizes links to sources, proposals, suggestions and
-        feedbacks mentioned in sidenotes and is not meant to be included in the
-        final document but merely as a support for editing.
+        feedbacks mentioned in sidenotes.
       </p>
       <ul>
         <li>


### PR DESCRIPTION
I've been using a working draft of my own as an evolving representation of group consensus. This PR brings that document into the main WebID repo, as requested and discussed in #37 and #44.