### PR TITLE
feat: adds a basic README.md and an empty CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+
+# WebID Community Group
+
+ This repository contains the source code of the [W3C WebID Community
+ Group](https://www.w3.org/groups/cg/webid/) (CG) processes and work items.
+
+ ## Participation
+
+ All substantive contributors to work items must be members of the WebID CG.
+ It’s easy to [join the CG](https://www.w3.org/community/webid/join) if you’d
+ like to contribute. Guests are welcome but do not have voting rights.
+
+ ## Contributing
+
+ See the [contributing
+ guide](https://github.com/w3c/WebID/blob/main/CONTRIBUTING.md) for detailed
+ instructions on how to get started with our project.
+
+ ## Code of Conduct
+
+ All documentation, code and communication under this repository are covered by
+ the [W3C Code of Ethics and Professional
+ Conduct](https://www.w3.org/Consortium/cepc/).


### PR DESCRIPTION
This PR walks the same path of #30 , though stopping a few steps earlier as per the provided feedback.

Regardless of whether this PR is accepted by the group or not, as chair I much prefer things to be explicit. The reference to https://www.w3.org/Consortium/cepc , though not necessary as this repo is implicitly governed by CEPC, is there because it immediately clarifies the matter of whether we have adopted a Code of Conduct or not without relying on a-priori knowledge on the reader's part. Any PR looking to add a README.md file _should_, in my opinion, make this explicit.

I've left the CONTRIBUTING.md file intentionally empty as it'll be the focus of different PRs.

EDIT: I've managed to get the spelling of CONTRIBUTING wrong in three different ways. New record.