### PR TITLE
feat: CONTRIBUTING.md based on current governance by lazy consensus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+
+# Contributing to the WebID Community Group
+
+Thank you for investing your time in contribution to the WebID Community Group!
+
+## Decisions
+
+This group is governed by _lazy consensus_ as defined in the [W3C Process 
+Document](https://www.w3.org/Consortium/Process/#decisions). What follows is
+a selection of quotes from that document which summarize how the group makes
+decisions. Please refer to the Process Document for more information.
+
+> Consensus is a core value of W3C. To promote consensus, the W3C process
+> requires Chairs to ensure that groups consider all legitimate views and
+> objections, and endeavor to resolve them, whether these views and objections
+> are expressed by the active participants of the group or by others [...]
+
+> Where unanimity is not possible, a group should strive to make consensus
+> decisions where there is significant support and few abstentions.
+
+> Chairs [...] may use [...] “lazy consensus”, in which lack of objection after
+> sufficient notice is taken as assent;
+
+> The Chair may record a decision where there is dissent so that the group can
+> make progress (for example, to produce a deliverable in a timely manner). 
+> Dissenters cannot stop a group’s work simply by saying that they cannot live 
+> with a decision. 
+
+> A group should only conduct a vote to resolve a substantive issue after the
+> Chair has determined that all available means of reaching consensus through 
+> technical discussion and compromise have failed, and that a vote is necessary 
+> to break a deadlock.
+
+## Contributions
+
+In order to be a substantive contributor to work items, you must be a member of
+the CG. It’s easy to [join the CG](https://www.w3.org/community/webid/join) if
+you’d like to contribute. People agree to the [W3C Community License Agreement
+(CLA)](http://www.w3.org/community/about/agreements/cla/) upon joining the CG.
+
+## Discussions
+
+If you'd like help troubleshooting a pull request (PR) you're working on, have a
+great new idea, or want to share implementation feedback, join us in any of the
+following venues:
+
+- [Our mailing list](https://lists.w3.org/Archives/Public/public-webid/)
+- [GitHub discussions](https://github.com/w3c/WebID/discussions)
+
+## Issues
+
+[Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues)
+are used to track tasks that contributors can help with.
+
+If you've found something in any of the working items within this repository,
+search open issues to see if someone else has reported the same thing. If it's
+something new, open an issue. We'll use the issue to have a conversation about
+the problem you want to fix.
+
+If you find an issue to work on, you are welcome to open a PR with a fix.
+The group will then decide whether to reject it, merge it or ask for further
+modifications.
+
+Issues are tracked and discussed on [GitHub](https://github.com/w3c/WebID/issues).
+
+## Communication
+
+The opinions of CG members may carry particular weight, whether they are
+expressed within our community or elsewhere. As a CG member:
+
+* It is assumed you are speaking as an individual unless you state otherwise.
+* If you want to express the opinion of your organisation or a group you are
+  affiliated with, make it clear before you state their view.
+* Do not use phrases like "on behalf of the CG" or "the CG thinks that" unless
+  the group has asked you to do so.
+* When communicating CG decisions, provide references to what was decided and
+  what was not decided.


### PR DESCRIPTION
This PR, which depends on #47, populates the CONTRIBUTING.md with a description of how the group operates at the moment of writing this, i.e. by means of lazy consensus.