### PR TITLE
chore: fix CI builds in forks

### DIFF
--- a/.github/workflows/bikeshed.yml
+++ b/.github/workflows/bikeshed.yml
@@ -30,7 +30,7 @@ jobs:
         uses: nrwl/nx-set-shas@v4
         with:
           main-branch-name: ${{ steps.branches.outputs.current_branch }}
-          error-on-no-successful-workflow: "true"
+          error-on-no-successful-workflow: "false"
           last-successful-event: "push"
           workflow-id: "bikeshed.yml"
     
@@ -80,3 +80,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'chore: process Bikeshed to HTML (CI)'
+          file_pattern: 'spec/identity/index.html'
+          add_options: '-f'
+          disable_globbing: true
+          skip_dirty_check: true


### PR DESCRIPTION
This PR fixes a couple of current pain points with our BikeShed CI build:

- It fixes the CI build in forks, which would break as the workflow would be unable to find a previous run for the same branch.
- ~~It forces committers to ignore local changes to the compiled `spec/identity/index.html` file while still allowing the CI build to commit changes brought in by each new run of BikeShed.~~ Nope, I wasn't to find a way to make this work.

Not the most elegant workflow I've ever seen but it appears to work well. Tagging @woutermont as the original author of the workflow and @TallTed as proponent of ignoring built files.

No deadline for review necessary as this is a fix to teething issues of #45 . Will definitely require a squash merge.