### PR TITLE
chore: adds 'working items' section and 'other relevant documents' section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,18 @@
  All documentation, code and communication under this repository are covered by
  the [W3C Code of Ethics and Professional
  Conduct](https://www.w3.org/Consortium/cepc/).
+
+ ## Working items
+
+- Working draft of the core specification (written using [BikeShed](bikeshed))
+  - source file: [./spec/identity/index.bs]()
+  - compiled file served as HTML: [https://w3c.github.io/WebID/spec/identity/index.html]()
+
+## Other relevant documents
+
+- 2014 ED of the core specification (written using [ReSpec](respec))
+  - source file: [./spec/drafts/ED-webid-20140305/identity/index.html]()
+  - source file served as HTML: [https://w3c.github.io/WebID/spec/drafts/ED-webid-20140305/identity/index.html]()
+
+[respec]: https://respec.org/docs/
+[bikeshed]: https://speced.github.io/bikeshed/

--- a/README.md
+++ b/README.md
@@ -1,40 +1,48 @@
 
 # WebID Community Group
 
- This repository contains the source code of the [W3C WebID Community
- Group](https://www.w3.org/groups/cg/webid/) (CG) processes and work items.
+This repository contains the source code of the [W3C WebID Community
+Group](https://www.w3.org/groups/cg/webid/) (CG) processes and work items.
 
- ## Participation
+## Participation
 
- All substantive contributors to work items must be members of the WebID CG.
- It’s easy to [join the CG](https://www.w3.org/community/webid/join) if you’d
- like to contribute. Guests are welcome but do not have voting rights.
+All substantive contributors to work items must be members of the WebID CG.
+It’s easy to [join the CG](https://www.w3.org/community/webid/join) if you’d
+like to contribute. Guests are welcome but do not have voting rights.
 
- ## Contributing
+## Contributing
 
- See the [contributing
- guide](https://github.com/w3c/WebID/blob/main/CONTRIBUTING.md) for detailed
- instructions on how to get started with our project.
+See the [contributing
+guide](https://github.com/w3c/WebID/blob/main/CONTRIBUTING.md) for detailed
+instructions on how to get started with our project.
 
- The work items are written using [Bikeshed](https://speced.github.io/bikeshed/), a preprocessor that automates a lot of modern spec-writing. [BUILD.md](https://github.com/w3c/WebID/blob/main/BUILD.md) contains a short guide on its usage.
+The work items are written using
+[Bikeshed](https://speced.github.io/bikeshed/), a preprocessor that automates a
+lot of modern spec-writing. 
+[BUILD.md](https://github.com/w3c/WebID/blob/main/BUILD.md) contains a short
+guide on its usage.
 
- ## Code of Conduct
+## Code of Conduct
 
- All documentation, code and communication under this repository are covered by
- the [W3C Code of Ethics and Professional
- Conduct](https://www.w3.org/Consortium/cepc/).
+All documentation, code and communication under this repository are covered by
+the [W3C Code of Ethics and Professional
+Conduct](https://www.w3.org/Consortium/cepc/).
 
- ## Working items
+## Working items
 
-- Working draft of the core specification (written using [BikeShed](bikeshed))
-  - source file: [./spec/identity/index.bs]()
-  - compiled file served as HTML: [https://w3c.github.io/WebID/spec/identity/index.html]()
+- Working draft of the core specification (written using [BikeShed][bikeshed])
+  - source file: [./spec/identity/index.bs](./spec/identity/index.bs)
+  - compiled file served as HTML:
+    https://w3c.github.io/WebID/spec/identity/index.html
 
 ## Other relevant documents
 
-- 2014 ED of the core specification (written using [ReSpec](respec))
-  - source file: [./spec/drafts/ED-webid-20140305/identity/index.html]()
-  - source file served as HTML: [https://w3c.github.io/WebID/spec/drafts/ED-webid-20140305/identity/index.html]()
+- 2014 ED of the core specification (written using [ReSpec][respec])
+  - source file: 
+    [./spec/drafts/ED-webid-20140305/identity/index.html][2014ED]
+  - source file served as HTML:
+    https://w3c.github.io/WebID/spec/drafts/ED-webid-20140305/identity/index.html
 
 [respec]: https://respec.org/docs/
 [bikeshed]: https://speced.github.io/bikeshed/
+[2014ED]: ./spec/drafts/ED-webid-20140305/identity/index.html


### PR DESCRIPTION
This PR takes care of adding links to working items and other relevant documents to the README.md file as per the respective subtask in https://github.com/w3c/WebID/issues/53 . I'm setting the review deadline to 2024-02-17 (in two days) as this PR does not introduce any change to the spec and #53 has been open for more than two weeks and was mentioned in two different _chair's overview_ emails.