### PR TITLE
feat: weakening the requirement on turtle in favor of orthogonality

### DIFF
--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -278,13 +278,11 @@ page).
 
 # Publishing the WebID Profile Document # {#publishing-the-webid-profile-document}
 
-[=WebID Profile Documents=] [MUST] be served using RDF serialization formats. 
+The [=Server=] [MUST] offer at least one RDF representation for a 
+[=WebID Profile Document=].
 
-[=WebID Profile Documents=] [SHOULD] be served using the [[!TURTLE]] format
-when the latter is requested by clients via the `Accept` HTTP header.
-
-[=WebID Profile Documents=] [MAY] additionally be served using any other format
-requested by a consumer via the `Accept` HTTP header.
+The [=Server=] [SHOULD] offer [[!TURTLE]] as one of the representations for a
+[=WebID Profile Document=].
 
 <div class="note" id="h_note_p1">
 

--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -119,10 +119,6 @@ A WebID is an HTTP URI that refers to an Agent (Person, Organization, Group,
 Device, etc.); a description of the Agent named by the WebID can be found in 
 the respective [=WebID Profile Document=].
 
-A [=WebID Profile Document=] is a Web resource that [MUST] be available as
-`text/turtle` [[!TURTLE]], but [MAY] be available in other RDF serialization
-formats (e.g., [[!RDFA-CORE]]) if requested through content negotiation.
-
 WebIDs can be used to build a Web of trust using vocabularies such as FOAF
 [[!FOAF]] by allowing people to link their profiles in a public or protected
 manner. Such a web of trust can then be used by a [=Service=] to make

--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -289,7 +289,7 @@ requested by a consumer via the `Accept` HTTP header.
 <div class="note" id="h_note_p1">
 
   RDF serialization formats include, but are not limited to, [[!JSON-LD11]], 
-  [[!TURTLE]] and [[!RDFA-CORE]].
+  [[!TURTLE]], and [[!RDFA-CORE]].
   
 </div>
 

--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -278,16 +278,31 @@ page).
 
 # Publishing the WebID Profile Document # {#publishing-the-webid-profile-document}
 
-This specification requires that servers [MUST] at least be able to provide a
-Turtle representation of WebID Profile Documents, but other serialization
-formats of the graph are allowed, provided that agents are able to parse that
-serialization and obtain the graph automatically. HTTP Content Negotiation can
-be employed to aid in publication and discovery of multiple distinct
-serializations of the same graph at the same URL, as explained in [[!COOLURIS]]
+[=WebID Profile Documents=] [MUST] be served using RDF serialization formats. 
 
-It is particularly useful to have one of the representations be in HTML even if
-it is not marked up in RDFa, as this allows people using a web browser to
-understand what the information at that URI represents.
+[=WebID Profile Documents=] [SHOULD] be served using the [[!TURTLE]] format
+when the latter is requested by clients via the `Accept` HTTP header.
+
+[=WebID Profile Documents=] [MAY] additionally be served using any other format
+requested by a consumer via the `Accept` HTTP header.
+
+<div class="note" id="h_note_p1">
+
+  RDF serialization formats include, but are not limited to, [[!JSON-LD11]], 
+  [[!TURTLE]] and [[!RDFA-CORE]].
+  
+</div>
+
+<div class="note" id="h_note_p2">
+
+  This specification does not mandate support for any specific format, 
+  following the principle of 
+  [Orthogonality of Specifications](https://www.w3.org/blog/2009/orthogonality-of-specification/).
+  In the interest of interoperability, however, this specification warmly and
+  earnestly suggests supporting the [[!TURTLE]] format, whether in addition to
+  other formats or as the only supported one.
+
+</div>
 
 ## WebID Profile Document Vocabulary ## {#webid-profile-vocabulary}
 


### PR DESCRIPTION
This PR weakens the current MUST on Turtle, favoring orthogonality, while still explicitly suggesting Turtle for interoperability. 

Quoting from https://github.com/w3c/WebID/issues/61#issuecomment-1960875026 :

> After spending a lot of time going through the comments in this thread, the ones in https://github.com/w3c/WebID/issues/3 , multiple threads of conversations on the mailing list and half a dozen private conversations with some of you, my preliminary conclusion is that the best way forward is to weaken the current MUST on Turtle into a SHOULD on Turtle. [...]
> 
> - The largest consensus that I can see lies with dropping all requirements (as in MUST) on serialization formats, favoring orthogonality. [...]
> - The second largest consensus that I can see lies with one MUST on a format if requested via the `Accept:` header, doesn't really matter which specific format, favoring interoperability. This is also informed by the view that most users and developers will interact with WebID parsing and serialization only indirectly.
> - While a breaking change is needed, this is arguably the least breaking change that can be made while still opening up the spec to JSON-LD and, indeed, any other format _(clarification: even when used exclusively)_. 
> - In addition to point 3., Turtle is arguably the least complex and onerous format to support from a technical standpoint. If a soft requirement (SHOULD) must be made for interoperability, a simpler format increases the chances that implementations will actually stick to such requirement.

Deadline for review is set to four weeks from now, on 2024-03-25. 

As always, the fact that a PR _exists_ doesn't automatically imply that it has to be merged at the end of its review period. This is the first attempt at addressing the issue of serialization formats, following countless comments and literal years of debate. Though I honestly believe that it does represent a good compromise (and the only one I could come up with), I'm fully aware that it might fail to gather enough consensus. The only thing I ask is to approach this with an open mind and some self-reflection on which specific hills each of us really wants to die on.

Do not bother reviewing the `spec/identity/index.html` as that's automatically updated by our current CI setup based on the contents of `spec/identity/index.bs`. We'll sort this out in a separate issue / PR.

EDIT: here's the links to the rendered files:

- main branch: https://w3c.github.io/WebID/spec/identity/index.html
- this PR: https://htmlpreview.github.io/?https://github.com/jacoscaz/WebID/blob/ci/feat/weaker-requirement-on-turtle/spec/identity/index.html