### PR TITLE
feat: uses IRI rather than URI or URL

### DIFF
--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -33,7 +33,7 @@ Abstract:
   over how each person can identify themselves in order to allow fine grained
   access control to their information on the Web. It does this by applying the
   best practices of Web Architecture whilst building on well established widely
-  deployed protocols and standards including HTML, URIs, HTTP, and RDF
+  deployed protocols and standards including HTML, URLs, HTTP, and RDF
   Semantics.
 
   <h3 id="how-to-read-this-document">How to Read this Document</h3>
@@ -115,9 +115,9 @@ Status Text:
 
 [NO-NORM]
 
-A WebID is an HTTP URI that refers to an Agent (Person, Organization, Group,
-Device, etc.); a description of the Agent named by the WebID can be found in 
-the respective [=WebID Profile Document=].
+A WebID is an IRI with a HTTP(S) scheme that refers to an Agent (Person,
+Organization, Group, Device, etc.); a description of the Agent named by the
+WebID can be found in the respective [=WebID Profile Document=].
 
 WebIDs can be used to build a Web of trust using vocabularies such as FOAF
 [[!FOAF]] by allowing people to link their profiles in a public or protected
@@ -182,9 +182,10 @@ document.
 
 : <dfn>WebID</dfn>
 
-:: An identifier in the form of an HTTP URI that unambiguously names an Agent
-    and, when dereferenced, always leads to a [=WebID Profile Document=]
-    which itself indicates that it describes the Agent named by the WebID.
+:: An identifier in the form of an IRI with a HTTP(S) scheme that
+    unambiguously names an Agent and, when dereferenced, always leads to a
+    [=WebID Profile Document=] which itself indicates that it describes the
+    Agent named by the WebID.
 
 : <dfn>WebID Profile Document</dfn>
 
@@ -215,17 +216,16 @@ stated:
 </table>
 
 
-# The WebID HTTP URI # {#the-webid-http-uri}
+# The WebID HTTP IRI # {#the-webid-http-uri}
 
-When using URIs, it is possible to identify both a thing (which may exist
-outside of the Web) and a Web document describing the thing. For example, the
-person Bob is described on his homepage. Alice may not like the look of Bob's
-homepage, but may want to link to the person Bob. Therefore, two URIs are
-needed, one for Bob and one for Bob's homepage (or an RDF document describing
-Bob).
+When using IRIs with a HTTP(s) scheme, it is possible to identify both a thing
+(which may exist outside of the Web) and a Web document describing the thing.
+For example, the person Bob is described on his homepage. Alice may not like
+the look of Bob's homepage, but may want to link to the person Bob. Therefore,
+two IRIs are needed, one for Bob and one for Bob's homepage (or an RDF document
+describing Bob).
 
-The WebID HTTP URI must be one that dereferences to a document the user
-controls.
+A WebID HTTP IRI must be one that dereferences to a document the user controls.
 
 For example, if a user Bob controls `https://bob.example.org/profile`, then his
 WebID can be `https://bob.example.org/profile#me`.
@@ -233,35 +233,55 @@ WebID can be `https://bob.example.org/profile#me`.
 <div class="note" id="h_note_1">
 
   There are two solutions that meet our requirements for identifying real-world
-  objects: 303 redirects and hash URIs. Which one to use depends on the
+  objects: 303 redirects and hash IRIs. Which one to use depends on the
   situation. Both have advantages and disadvantages, as presented in
-  [[!COOLURIS]]. All examples in this specification will use such hash URIs.
+  [[!COOLURIS]]. All examples in this specification will use such hash IRIs.
 
 </div>
 
+# WebID as a URL and WebID as an IRI # {#webid-as-url-iri}
+
+[NO-NORM]
+
+While a WebID is technically an [[!IRI]] with a HTTP(S) scheme, it can also
+generally be considered a WHATWG [[!URL]] with a HTTP(S) scheme. Implementers
+[SHOULD], however, prepare for the entire [[!IRI]] space.
+
+<div class="note" id="h_note_2">
+  This specification follows the definitions and constraints expressed in 
+  [Section 3.2](https://www.w3.org/TR/rdf12-concepts/#section-IRIs) of
+  [[!rdf12-concepts]] in relation to the usage of IRIs within RDF syntax and
+  their relationship with URIs and URLs.
+</div>
+
+<div class="note" id="h_note_2">
+  This specification defers to the procedures defined in
+  [Section 3](https://www.rfc-editor.org/rfc/rfc3987#section-3) of [[!rfc3987]]
+  in relation to the mapping and conversion between the IRI and URI spaces.
+</div>
 
 # Overview # {#overview}
 
 [NO-NORM]
 
-The relation between the [=WebID=] URI and the [=WebID Profile Document=] is
+The relation between the [=WebID=] IRI and the [=WebID Profile Document=] is
 illustrated below.
 
 <img src="img/WebID-overview.png" alt="WebID overview" id="webid-diagram"
 class="full-width">
 
-The WebID URI — <em>"<a href="http://www.w3.org/People/Berners-Lee/card#i"
+The WebID IRI — <em>"<a href="http://www.w3.org/People/Berners-Lee/card#i"
 >http://www.w3.org/People/Berners-Lee/card<strong>#i</strong></a>"</em>
 (containing the **#i** hash tag) — is an identifier that denotes (refers to) a
 person or more generally an agent. In the above illustration, the referent is
 Tim Berners Lee, a real physical person who has a history, who invented the
 World Wide Web, and who directs the World Web Consortium.
 
-The WebID Profile Document URI — <em>"<a 
+The WebID Profile Document IRI — <em>"<a 
 href="http://www.w3.org/People/Berners-Lee/card"
 >http://www.w3.org/People/Berners-Lee/card</a>"</em> (without the **#i** hash
 tag) — denotes the document describing the person (or more generally any agent)
-who is the referent of the WebID URI.
+who is the referent of the WebID IRI.
 
 The WebID Profile Document gives the meaning of the WebID: its RDF Graph
 contains a [Concise Bounded Description](http://www.w3.org/Submission/CBD/) of

--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -233,7 +233,7 @@ WebID can be `https://bob.example.org/profile#me`.
 <div class="note" id="h_note_1">
 
   There are two solutions that meet our requirements for identifying real-world
-  objects: 303 redirects and hash IRIs. Which one to use depends on the
+  objects: 303 redirects and hash IRIs. Which one is best to use depends on the
   situation. Both have advantages and disadvantages, as presented in
   [[!COOLURIS]]. All examples in this specification will use such hash IRIs.
 
@@ -245,19 +245,19 @@ WebID can be `https://bob.example.org/profile#me`.
 
 While a WebID is technically an [[!IRI]] with a HTTP(S) scheme, it can also
 generally be considered a WHATWG [[!URL]] with a HTTP(S) scheme. Implementers
-[SHOULD], however, prepare for the entire [[!IRI]] space.
+[SHOULD] prepare for the entire [[!IRI]] space.
 
 <div class="note" id="h_note_2">
   This specification follows the definitions and constraints expressed in 
   [Section 3.2](https://www.w3.org/TR/rdf12-concepts/#section-IRIs) of
-  [[!rdf12-concepts]] in relation to the usage of IRIs within RDF syntax and
+  [[!rdf12-concepts]] regarding the use of IRIs within RDF syntax and
   their relationship with URIs and URLs.
 </div>
 
 <div class="note" id="h_note_2">
   This specification defers to the procedures defined in
   [Section 3](https://www.rfc-editor.org/rfc/rfc3987#section-3) of [[!IRI]]
-  in relation to the mapping and conversion between the IRI and URI spaces.
+  regarding mapping and conversion between the IRI and URI spaces.
 </div>
 
 # Overview # {#overview}
@@ -272,16 +272,16 @@ class="full-width">
 
 The WebID IRI — <em>"<a href="http://www.w3.org/People/Berners-Lee/card#i"
 >http://www.w3.org/People/Berners-Lee/card<strong>#i</strong></a>"</em>
-(containing the **#i** hash tag) — is an identifier that denotes (refers to) a
-person or more generally an agent. In the above illustration, the referent is
-Tim Berners Lee, a real physical person who has a history, who invented the
-World Wide Web, and who directs the World Web Consortium.
+(containing the **#i** fragment identifier) — is an identifier that denotes
+(refers to) a person or more generally an agent. In the above illustration,
+the referent is Tim Berners Lee, a real physical person who has a history,
+who invented the World Wide Web, and who directs the World Web Consortium.
 
 The WebID Profile Document IRI — <em>"<a 
 href="http://www.w3.org/People/Berners-Lee/card"
->http://www.w3.org/People/Berners-Lee/card</a>"</em> (without the **#i** hash
-tag) — denotes the document describing the person (or more generally any agent)
-who is the referent of the WebID IRI.
+>http://www.w3.org/People/Berners-Lee/card</a>"</em> (without the **#i**
+fragment identifier) — denotes the document describing the person (or more
+generally any agent) who is the referent of the WebID IRI.
 
 The WebID Profile Document gives the meaning of the WebID: its RDF Graph
 contains a [Concise Bounded Description](http://www.w3.org/Submission/CBD/) of

--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -256,7 +256,7 @@ generally be considered a WHATWG [[!URL]] with a HTTP(S) scheme. Implementers
 
 <div class="note" id="h_note_2">
   This specification defers to the procedures defined in
-  [Section 3](https://www.rfc-editor.org/rfc/rfc3987#section-3) of [[!rfc3987]]
+  [Section 3](https://www.rfc-editor.org/rfc/rfc3987#section-3) of [[!IRI]]
   in relation to the mapping and conversion between the IRI and URI spaces.
 </div>
 


### PR DESCRIPTION
This PR closes long-standing #10 by replacing usages of "URI" with "IRI" and expanding on the relationship between IRIs, URIs and URLs, referencing and deferring to higher-level specs.

Though theoretically a breaking change, in practice this PR changes little to nothing. Setting the deadline for review in two weeks, on 2024-04-01.

Do not bother reviewing the `spec/identity/index.html` as that's automatically updated by our current CI setup based on the contents of `spec/identity/index.bs`. We'll sort this out in a separate issue / PR.

EDIT: links to the rendered files:

- main branch: https://w3c.github.io/WebID/spec/identity/index.html
- this PR: https://htmlpreview.github.io/?https://github.com/jacoscaz/WebID/blob/ci/feat/iri-uri/spec/identity/index.html