### PR TITLE
feat: rename WebID Profile Document to WebID Document

### DIFF
--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -117,7 +117,7 @@ Status Text:
 
 A WebID is an HTTP URI that refers to an Agent (Person, Organization, Group,
 Device, etc.); a description of the Agent named by the WebID can be found in 
-the respective [=WebID Profile Document=].
+the respective [=WebID Document=].
 
 WebIDs can be used to build a Web of trust using vocabularies such as FOAF
 [[!FOAF]] by allowing people to link their profiles in a public or protected
@@ -148,16 +148,16 @@ used terms in this document.
 [[#the-webid-http-uri|Section 3]] describes what a WebID is.
 
 [[#overview|Section 4]] illustrates the relationship between a WebID, the Agent
-that is named by it, and the respective [=WebID Profile Document=].
+that is named by it, and the respective [=WebID Document=].
 
 [[#webid-profile-contents|Section 5]] defines the required and some suggested
-contents of a [=WebID Profile Document=] 
+contents of a [=WebID Document=] 
 
 [[#publishing-the-webid-profile-document|Section 6]] deals with the publishing
-of a [=WebID Profile Document=].
+of a [=WebID Document=].
 
 [[#processing-the-webid-profile|Section 7]] describes how a request for a
-[=WebID Profile Document=] should be handled.
+[=WebID Document=] should be handled.
 
 
 # Terminology # {#terminology}
@@ -183,10 +183,10 @@ document.
 : <dfn>WebID</dfn>
 
 :: An identifier in the form of an HTTP URI that unambiguously names an Agent
-    and, when dereferenced, always leads to a [=WebID Profile Document=]
+    and, when dereferenced, always leads to a [=WebID Document=]
     which itself indicates that it describes the Agent named by the WebID.
 
-: <dfn>WebID Profile Document</dfn>
+: <dfn>WebID Document</dfn>
 
 :: An RDF document that describes an Agent.
 
@@ -244,7 +244,7 @@ WebID can be `https://bob.example.org/profile#me`.
 
 [NO-NORM]
 
-The relation between the [=WebID=] URI and the [=WebID Profile Document=] is
+The relation between the [=WebID=] URI and the [=WebID Document=] is
 illustrated below.
 
 <img src="img/WebID-overview.png" alt="WebID overview" id="webid-diagram"
@@ -257,17 +257,17 @@ person or more generally an agent. In the above illustration, the referent is
 Tim Berners Lee, a real physical person who has a history, who invented the
 World Wide Web, and who directs the World Web Consortium.
 
-The WebID Profile Document URI — <em>"<a 
+The WebID Document URI — <em>"<a 
 href="http://www.w3.org/People/Berners-Lee/card"
 >http://www.w3.org/People/Berners-Lee/card</a>"</em> (without the **#i** hash
 tag) — denotes the document describing the person (or more generally any agent)
 who is the referent of the WebID URI.
 
-The WebID Profile Document gives the meaning of the WebID: its RDF Graph
+The WebID Document gives the meaning of the WebID: its RDF Graph
 contains a [Concise Bounded Description](http://www.w3.org/Submission/CBD/) of
 the WebID such that this subgraph forms a definite description of the referent
 of the WebID, that is, a description that distinguishes the referent of that
-WebID from all other things in the world. <br /> The WebID Profile Document
+WebID from all other things in the world. <br /> The WebID Document
 can, for example, contain relations to other documents depicting the WebID
 referent, or it can relate the WebID to principals used by different
 authentication protocols. (More information on WebID and other authentication
@@ -276,13 +276,13 @@ Interoperability](http://www.w3.org/2005/Incubator/webid/wiki/Identity_Interoper
 page).
 
 
-# Publishing the WebID Profile Document # {#publishing-the-webid-profile-document}
+# Publishing the WebID Document # {#publishing-the-webid-profile-document}
 
 The [=Server=] [MUST] offer at least one RDF representation for a 
-[=WebID Profile Document=].
+[=WebID Document=].
 
 The [=Server=] [SHOULD] offer [[!TURTLE]] as one of the representations for a
-[=WebID Profile Document=].
+[=WebID Document=].
 
 <div class="note" id="h_note_p1">
 
@@ -302,17 +302,17 @@ The [=Server=] [SHOULD] offer [[!TURTLE]] as one of the representations for a
 
 </div>
 
-## WebID Profile Document Vocabulary ## {#webid-profile-vocabulary}
+## WebID Document Vocabulary ## {#webid-profile-vocabulary}
 
 WebID RDF graphs are built using vocabularies identified by URIs, that can be
 placed in subject, predicate or object position of the relations constituting
 the graph. The definition of each URI should be found at the namespace of the
 URI, by dereferencing it.
 
-### Contents of a WebID Profile Document ### {#webid-profile-contents}
+### Contents of a WebID Document ### {#webid-profile-contents}
 
-A [=WebID Profile Document=] [MUST] qualify the described Agent as the
-document's `foaf:primaryTopic`. Furthermore, a [=WebID Profile Document=]
+A [=WebID Document=] [MUST] qualify the described Agent as the
+document's `foaf:primaryTopic`. Furthermore, a [=WebID Document=]
 [SHOULD] also qualify the described Agent as having type `foaf:Agent`.
 
 Personal details are the most common requirement when registering an account
@@ -345,11 +345,11 @@ A widely used format for writing RDF graphs by hand is the
 [Turtle](http://www.w3.org/TR/turtle/) [[!TURTLE]] notation. It is easy to
 learn, and very handy for communicating over e-mail and on mailing lists. The
 syntax is very similar to the \[SPARQL](http://www.w3.org/TR/rdf-sparql-query/)
-query language. WebID Profile Documents in Turtle should be served with the
+query language. WebID Documents in Turtle should be served with the
 `text/turtle` content type.
 
 Take for example the WebID *https://bob.example.org/profile#me*, for which the
-WebID Profile Document contains the following Turtle representation:
+WebID Document contains the following Turtle representation:
 
 <div class="example" id="ex-webid-profile-turtle">
   <pre highlight="turtle">
@@ -367,14 +367,14 @@ WebID Profile Document contains the following Turtle representation:
 </div>
 
 
-## Publishing a WebID Profile Document using the RDFa HTML notation ## {#publishing-a-webid-profile-using-the-rdfa-html-notation}
+## Publishing a WebID Document using the RDFa HTML notation ## {#publishing-a-webid-profile-using-the-rdfa-html-notation}
 
 [NO-NORM]
 
 RDFa in HTML [[!RDFA-CORE]] is a way to markup HTML with relations that have a
 well defined semantics and mapping to an RDF graph. There are many ways of
 writing out the above graph using RDFa in HTML. Here is just one example of
-what a WebID Profile Document could look like.
+what a WebID Document could look like.
 
 <div class="example" id="ex-webid-profile-rdfa">
   <pre highlight="html">
@@ -388,7 +388,7 @@ what a WebID Profile Document could look like.
   </pre>
 </div>
 
-If a WebID provider would prefer not to mark up his WebID Profile Document in
+If a WebID provider would prefer not to mark up his WebID Document in
 HTML+RDFa, but just provide a human readable format for users in plain HTML and
 have the RDF graph appear in a machine readable format such as Turtle, then he
 [SHOULD] provide a link of type `alternate` to a machine readable format
@@ -411,7 +411,7 @@ here:
 
 [NO-NORM]
 
-A WebID Profile Document may contain public as well as private information
+A WebID Document may contain public as well as private information
 about the agent named by the WebID. As some agents may not want to reveal
 a lot of information about themselves, RDF and Linked Data principles allows
 them to choose how much information they wish to make publicly available. This
@@ -476,11 +476,11 @@ and having the following corresponding ACL rule, expressed using the
 [NO-NORM]
 
 A [=WebID=] identifies an agent via a description found in the associated
-[=WebID Profile Document=]. An agent that wishes to know what a WebID refers
+[=WebID Document=]. An agent that wishes to know what a WebID refers
 to, must rely on the description found in the WebID Profile. An attack on the
-relation between the [=WebID=] and the [=WebID Profile Document=] can thus be
+relation between the [=WebID=] and the [=WebID Document=] can thus be
 used to subvert the meaning of the WebID, and to make agents following links
-within the [=WebID Profile Document=] come to different conclusions from those
+within the [=WebID Document=] come to different conclusions from those
 intended by profile owners.
 
 The standard way of overcoming such attacks is to rely on the cryptographic
@@ -504,8 +504,8 @@ Wiki](http://www.w3.org/2005/Incubator/webid/wiki/Identity_Security).
 
 # Processing the WebID Profile # {#processing-the-webid-profile}
 
-The [=Requesting Agent=] needs to fetch the WebID Profile Document, if it does
-not have a valid one in cache. The Agent requesting the WebID Profile Document
+The [=Requesting Agent=] needs to fetch the WebID Document, if it does
+not have a valid one in cache. The Agent requesting the WebID Document
 [MUST] be able to parse documents in Turtle [[!TURTLE]], but [MAY] also be able
 to parse documents in RDF/XML [[!RDF-SYNTAX-GRAMMAR]] and RDFa [[!RDFA-CORE]].
 The result of this processing should be a graph of RDF relations that is

--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -276,7 +276,7 @@ Interoperability](http://www.w3.org/2005/Incubator/webid/wiki/Identity_Interoper
 page).
 
 
-# Publishing the WebID Document # {#publishing-the-webid-profile-document}
+# Publishing the WebID Document # {#publishing-the-webid-profile-document}{#publishing-the-webid-document}
 
 The [=Server=] [MUST] offer at least one RDF representation for a 
 [=WebID Document=].
@@ -302,14 +302,14 @@ The [=Server=] [SHOULD] offer [[!TURTLE]] as one of the representations for a
 
 </div>
 
-## WebID Document Vocabulary ## {#webid-profile-vocabulary}
+## WebID Document Vocabulary ## {#webid-profile-vocabulary}{#webid-document-vocabulary}
 
 WebID RDF graphs are built using vocabularies identified by URIs, that can be
 placed in subject, predicate or object position of the relations constituting
 the graph. The definition of each URI should be found at the namespace of the
 URI, by dereferencing it.
 
-### Contents of a WebID Document ### {#webid-profile-contents}
+### Contents of a WebID Document ### {#webid-profile-contents}{#webid-document-contents}
 
 A [=WebID Document=] [MUST] qualify the described Agent as the
 document's `foaf:primaryTopic`. Furthermore, a [=WebID Document=]
@@ -367,7 +367,7 @@ WebID Document contains the following Turtle representation:
 </div>
 
 
-## Publishing a WebID Document using the RDFa HTML notation ## {#publishing-a-webid-profile-using-the-rdfa-html-notation}
+## Publishing a WebID Document using the RDFa HTML notation ## {#publishing-a-webid-profile-using-the-rdfa-html-notation}{#publishing-a-webid-document-using-the-rdfa-html-notation}
 
 [NO-NORM]
 
@@ -502,7 +502,7 @@ available on the [WebID
 Wiki](http://www.w3.org/2005/Incubator/webid/wiki/Identity_Security).
 
 
-# Processing the WebID Profile # {#processing-the-webid-profile}
+# Processing the WebID Profile # {#processing-the-webid-profile}{#processing-the-webid-document}
 
 The [=Requesting Agent=] needs to fetch the WebID Document, if it does
 not have a valid one in cache. The Agent requesting the WebID Document

--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -388,7 +388,7 @@ what a WebID Document could look like.
   </pre>
 </div>
 
-If a WebID provider would prefer not to mark up his WebID Document in
+If a WebID provider would prefer not to mark up their WebID Document in
 HTML+RDFa, but just provide a human readable format for users in plain HTML and
 have the RDF graph appear in a machine readable format such as Turtle, then he
 [SHOULD] provide a link of type `alternate` to a machine readable format

--- a/spec/identity/index.bs
+++ b/spec/identity/index.bs
@@ -150,13 +150,13 @@ used terms in this document.
 [[#overview|Section 4]] illustrates the relationship between a WebID, the Agent
 that is named by it, and the respective [=WebID Document=].
 
-[[#webid-profile-contents|Section 5]] defines the required and some suggested
+[[#webid-document-contents|Section 5]] defines the required and some suggested
 contents of a [=WebID Document=] 
 
-[[#publishing-the-webid-profile-document|Section 6]] deals with the publishing
+[[#publishing-the-webid-document|Section 6]] deals with the publishing
 of a [=WebID Document=].
 
-[[#processing-the-webid-profile|Section 7]] describes how a request for a
+[[#processing-the-webid-document|Section 7]] describes how a request for a
 [=WebID Document=] should be handled.
 
 


### PR DESCRIPTION
This PR addresses the change requested in #20 . While there appears to be a slightly greater consensus in favor of `WebID Document` over `WebID Profile Document`, the difference is so small that feedback to this PR might tilt the balance towards the latter and negate the need for a change. Let's see what happens. 
 
This PR does not introduce any breaking change. Setting the deadline for review in two weeks, on 2024-04-01.

Do not bother reviewing the `spec/identity/index.html` as that's automatically updated by our current CI setup based on the contents of `spec/identity/index.bs`. We'll sort this out in a separate issue / PR.

Links to the rendered files:

- main branch: https://w3c.github.io/WebID/spec/identity/index.html
- this PR: https://htmlpreview.github.io/?https://github.com/jacoscaz/WebID/blob/ci/feat/rename-webid-profile-document-to-webid-document/spec/identity/index.html